### PR TITLE
Update Samples~ folder with latest scripts, scene, and prefabs

### DIFF
--- a/Samples~/ExampleScene/ExampleAdsScene.unity
+++ b/Samples~/ExampleScene/ExampleAdsScene.unity
@@ -164,6 +164,142 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 14252521}
   m_CullTransparentMesh: 0
+--- !u!1 &287891060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 287891061}
+  - component: {fileID: 287891063}
+  - component: {fileID: 287891062}
+  m_Layer: 5
+  m_Name: ShowRewardedAdText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &287891061
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287891060}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1928752704}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &287891062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287891060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Open
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 58
+  m_fontSizeBase: 58
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 5
+  m_fontSizeMax: 58
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 0
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &287891063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 287891060}
+  m_CullTransparentMesh: 0
 --- !u!1 &293819975
 GameObject:
   m_ObjectHideFlags: 0
@@ -565,8 +701,8 @@ MonoBehaviour:
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1080, y: 1920}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0.79
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 1
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -612,6 +748,7 @@ RectTransform:
   - {fileID: 5475124235467500490}
   - {fileID: 4430844100046515577}
   - {fileID: 1146369655}
+  - {fileID: 1809374686}
   - {fileID: 2030981598}
   - {fileID: 1102068525}
   m_Father: {fileID: 0}
@@ -637,9 +774,11 @@ MonoBehaviour:
   showInterstitialBtn: {fileID: 1656420485}
   toggleBannerBtn: {fileID: 2030981599}
   toggleRemoveAdsBtn: {fileID: 1102068526}
+  privacyOptionsBtn: {fileID: 1928752705}
   debugLogText: {fileID: 1687243073}
   showDetailedLogs: 1
   testBannerPosition: 1
+  privacyButtonMode: 1
 --- !u!1 &956475538
 GameObject:
   m_ObjectHideFlags: 0
@@ -751,7 +890,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0.118854165}
-  m_AnchoredPosition: {x: 3.0999756, y: 215}
+  m_AnchoredPosition: {x: 3.1000977, y: 215}
   m_SizeDelta: {x: -208.03516, y: -95.41406}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &1102068526
@@ -1526,6 +1665,43 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_HorizontalFit: 0
   m_VerticalFit: 2
+--- !u!1 &1809374685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1809374686}
+  m_Layer: 5
+  m_Name: PrivacyOptions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1809374686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809374685}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1938799764}
+  - {fileID: 1928752704}
+  m_Father: {fileID: 717375339}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -435.97998, y: -77.299805}
+  m_SizeDelta: {x: 871.9619, y: 154.80005}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &1883359340
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1538,9 +1714,25 @@ PrefabInstance:
       propertyPath: m_Name
       value: VerifyandInitializeAdmob
       objectReference: {fileID: 0}
+    - target: {fileID: 2310368041958125014, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695954469106698152, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
+      propertyPath: showBannerOnStart
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695954469106698152, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
+      propertyPath: useAdaptiveBanners
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2695954469106698152, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
       propertyPath: enableConsentDebugging
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695954469106698152, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
+      propertyPath: alwaysRequestConsentUpdate
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2784422891448605819, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1587,6 +1779,263 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f28ac14ac7fdbbb4e810e3a099000ea9, type: 3}
+--- !u!1 &1928752703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1928752704}
+  - component: {fileID: 1928752707}
+  - component: {fileID: 1928752706}
+  - component: {fileID: 1928752705}
+  m_Layer: 5
+  m_Name: ShowRewardedAd
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1928752704
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928752703}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 287891061}
+  m_Father: {fileID: 1809374686}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 300.09, y: 0}
+  m_SizeDelta: {x: 270, y: 120}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1928752705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928752703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Highlighted
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1928752706}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1928752706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928752703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1928752707
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928752703}
+  m_CullTransparentMesh: 0
+--- !u!1 &1938799763
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1938799764}
+  - component: {fileID: 1938799766}
+  - component: {fileID: 1938799765}
+  m_Layer: 5
+  m_Name: RewardedAdText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1938799764
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938799763}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1809374686}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 299.6478, y: 121.15591}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1938799765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938799763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Privacy Options :'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4293717228
+  m_fontColor: {r: 0.9245283, g: 0.9245283, b: 0.9245283, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 58
+  m_fontSizeBase: 58
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 2
+  m_fontSizeMax: 58
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 0
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1938799766
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938799763}
+  m_CullTransparentMesh: 0
 --- !u!114 &2011352499
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1714,7 +2163,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0.118854165}
-  m_AnchoredPosition: {x: 3.0999756, y: 411}
+  m_AnchoredPosition: {x: 3.1000977, y: 411}
   m_SizeDelta: {x: -208.03516, y: -95.41406}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &2030981599

--- a/Samples~/ExampleScene/Scripts/AdsExampleUI.cs
+++ b/Samples~/ExampleScene/Scripts/AdsExampleUI.cs
@@ -1,0 +1,612 @@
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using GoogleMobileAds.Api;
+using Autech.Admob;
+
+public class AdsExampleUI : MonoBehaviour
+{
+    public Button showRewardedBtn;
+    public Button showInterstitialBtn;
+    public Button toggleBannerBtn;
+    public Button toggleRemoveAdsBtn;
+    public Button privacyOptionsBtn;
+
+    [Header("Debug Logging")]
+    public TMP_Text debugLogText;
+
+    Action Success, Fail;
+    Action<Reward> OnRewardGranted;
+
+    [Header("Test Configuration")]
+    [SerializeField] private bool showDetailedLogs = true;
+    [SerializeField] private BannerPosition testBannerPosition = BannerPosition.Bottom;
+    
+    [Header("Privacy Options Display")]
+    [Tooltip("How to display the Privacy Options button when not required")]
+    [SerializeField] private PrivacyButtonDisplayMode privacyButtonMode = PrivacyButtonDisplayMode.DisabledWhenNotRequired;
+    
+    public enum PrivacyButtonDisplayMode
+    {
+        AlwaysVisible,              // Always show button, enable/disable based on requirement (Google recommendation)
+        DisabledWhenNotRequired,    // Show button but grey out when not required (current default)
+        HideWhenNotRequired         // Completely hide button when not required (minimum compliance)
+    }
+
+    private string textLog = "ADMOB DEBUG LOG: \n";
+
+    // Event-based logging system
+    public delegate void DebugEvent(string msg);
+    public static event DebugEvent OnDebugLog;
+
+    private void Start()
+    {
+        showRewardedBtn.onClick.AddListener(() => CallRewarded(3));
+        showInterstitialBtn.onClick.AddListener(() => CallInterstitial(2));
+        toggleBannerBtn.onClick.AddListener(ToggleBannerTestCall);
+        toggleRemoveAdsBtn.onClick.AddListener(TestToggleRemoveAds);
+        
+        if (privacyOptionsBtn != null)
+            privacyOptionsBtn.onClick.AddListener(ShowPrivacyOptions);
+            
+        InvokeRepeating(nameof(UpdateButtonStates), 0f, 1f);
+        
+        SubscribeToConsentEvents();
+    }
+
+    private void OnEnable()
+    {
+        AdsExampleUI.OnDebugLog += HandleDebugLog;
+    }
+
+    private void OnDisable()
+    {
+        AdsExampleUI.OnDebugLog -= HandleDebugLog;
+        UnsubscribeFromConsentEvents();
+    }
+
+    private void HandleDebugLog(string msg)
+    {
+        textLog += "\n" + msg + "\n";
+        if (debugLogText != null)
+        {
+            debugLogText.text = textLog;
+        }
+    }
+
+    private void UpdateButtonStates()
+    {
+        if (showRewardedBtn != null)
+            showRewardedBtn.interactable = AdsManager.Instance.IsRewardedReady();
+
+        if (showInterstitialBtn != null)
+            showInterstitialBtn.interactable = AdsManager.Instance.IsInterstitialReady();
+
+        if (toggleBannerBtn != null)
+            toggleBannerBtn.interactable = AdsManager.Instance.IsBannerLoaded();
+
+        if (toggleRemoveAdsBtn != null)
+        {
+            bool removeAdsEnabled = AdsManager.Instance.RemoveAds;
+            Image image = toggleRemoveAdsBtn.GetComponent<Image>();
+
+            if (removeAdsEnabled)
+            {
+                image.color = Color.red;
+            }
+            else
+            {
+                image.color = Color.green;
+            }
+        }
+        
+        if (privacyOptionsBtn != null)
+        {
+            bool isRequired = AdsManager.Instance.ShouldShowPrivacyOptionsButton();
+            
+            switch (privacyButtonMode)
+            {
+                case PrivacyButtonDisplayMode.AlwaysVisible:
+                    // Always show and enable button (best practice)
+                    privacyOptionsBtn.gameObject.SetActive(true);
+                    privacyOptionsBtn.interactable = true;
+                    break;
+                    
+                case PrivacyButtonDisplayMode.DisabledWhenNotRequired:
+                    // Show button but disable when not required (current behavior)
+                    privacyOptionsBtn.gameObject.SetActive(true);
+                    privacyOptionsBtn.interactable = isRequired;
+                    break;
+                    
+                case PrivacyButtonDisplayMode.HideWhenNotRequired:
+                    // Completely hide button when not required (minimum compliance)
+                    privacyOptionsBtn.gameObject.SetActive(isRequired);
+                    privacyOptionsBtn.interactable = isRequired;
+                    break;
+            }
+        }
+    }
+
+    #region Interstitial Ads
+    public void CallInterstitial(int number)
+    {
+        LogTest($"Testing Interstitial Ad (Method {number})");
+
+        switch (number)
+        {
+            case 0:
+                Success = OnSuccessInter;
+                AdsManager.Instance.ShowInterstitial(Success);
+                break;
+            case 1:
+                AdsManager.Instance.ShowInterstitial();
+                break;
+            case 2:
+                Success = OnSuccessInter;
+                Fail = OnFailInter;
+                AdsManager.Instance.ShowInterstitial(Success, Fail);
+                break;
+        }
+    }
+
+    private void OnSuccessInter()
+    {
+        LogTest("Interstitial Ad closed successfully");
+    }
+
+    private void OnFailInter()
+    {
+        LogTest("Interstitial Ad failed to show");
+    }
+    #endregion
+
+    #region Rewarded Ads
+    public void CallRewarded(int number)
+    {
+        LogTest($"Testing Rewarded Ad (Method {number})");
+
+        switch (number)
+        {
+            case 0:
+                Success = OnSuccessRewarded;
+                AdsManager.Instance.ShowRewarded(Success);
+                break;
+            case 1:
+                AdsManager.Instance.ShowRewarded();
+                break;
+            case 2:
+                Success = OnSuccessRewarded;
+                Fail = OnFailRewarded;
+                AdsManager.Instance.ShowRewarded(Success, Fail);
+                break;
+            case 3:
+                OnRewardGranted = OnRewardedAdReward;
+                Success = OnSuccessRewarded;
+                Fail = OnFailRewarded;
+                AdsManager.Instance.ShowRewarded(OnRewardGranted, Success, Fail);
+                break;
+        }
+    }
+
+    private void OnSuccessRewarded()
+    {
+        LogTest("Rewarded Ad closed successfully");
+    }
+
+    private void OnFailRewarded()
+    {
+        LogTest("Rewarded Ad failed to show");
+    }
+
+    private void OnRewardedAdReward(Reward reward)
+    {
+        LogTest($"Reward Granted! Amount: {reward.Amount}, Type: {reward.Type}");
+    }
+    #endregion
+
+    #region Rewarded Interstitial Ads
+    public void CallRewardedInterstitial(int number)
+    {
+        LogTest($"Testing Rewarded Interstitial Ad (Method {number})");
+
+        switch (number)
+        {
+            case 0:
+                Success = OnSuccessRewardedInter;
+                AdsManager.Instance.ShowRewardedInterstitial(Success);
+                break;
+            case 1:
+                AdsManager.Instance.ShowRewardedInterstitial();
+                break;
+            case 2:
+                Success = OnSuccessRewardedInter;
+                Fail = OnFailRewardedInter;
+                AdsManager.Instance.ShowRewardedInterstitial(Success, Fail);
+                break;
+            case 3:
+                OnRewardGranted = OnRewardedInterAdReward;
+                Success = OnSuccessRewardedInter;
+                Fail = OnFailRewardedInter;
+                AdsManager.Instance.ShowRewardedInterstitial(OnRewardGranted, Success, Fail);
+                break;
+        }
+    }
+
+    private void OnSuccessRewardedInter()
+    {
+        LogTest("Rewarded Interstitial Ad closed successfully");
+    }
+
+    private void OnFailRewardedInter()
+    {
+        LogTest("Rewarded Interstitial Ad failed to show");
+    }
+
+    private void OnRewardedInterAdReward(Reward reward)
+    {
+        LogTest($"Rewarded Interstitial Reward! Amount: {reward.Amount}, Type: {reward.Type}");
+    }
+    #endregion
+
+    #region App Open Ads
+    public void CallAppOpen(int number)
+    {
+        LogTest($"Testing App Open Ad (Method {number})");
+
+        switch (number)
+        {
+            case 0:
+                Success = OnSuccessAppOpen;
+                AdsManager.Instance.ShowAppOpenAd(Success);
+                break;
+            case 1:
+                AdsManager.Instance.ShowAppOpenAd();
+                break;
+            case 2:
+                Success = OnSuccessAppOpen;
+                Fail = OnFailAppOpen;
+                AdsManager.Instance.ShowAppOpenAd(Success, Fail);
+                break;
+        }
+    }
+
+    private void OnSuccessAppOpen()
+    {
+        LogTest("App Open Ad closed successfully");
+    }
+
+    private void OnFailAppOpen()
+    {
+        LogTest("App Open Ad failed to show");
+    }
+    #endregion
+
+    #region Banner Ads
+    public void ShowBannerTestCall()
+    {
+        LogTest("Showing Banner Ad");
+        AdsManager.Instance.ShowBanner(true);
+    }
+
+    public void HideBannerTestCall()
+    {
+        LogTest("Hiding Banner Ad");
+        AdsManager.Instance.ShowBanner(false);
+    }
+
+    public void ToggleBannerTestCall()
+    {
+        bool isVisible = AdsManager.Instance.IsBannerVisible();
+        AdsManager.Instance.ShowBanner(!isVisible);
+        LogTest($"Toggling Banner Ad (Currently: {(!isVisible ? "Visible" : "Hidden")})");
+    }
+
+    public void ChangeBannerPosition()
+    {
+        LogTest($"Changing Banner Position to: {testBannerPosition}");
+        AdsManager.Instance.SetBannerPosition(testBannerPosition);
+    }
+
+    public void CycleBannerPosition()
+    {
+        BannerPosition[] positions = {
+            BannerPosition.Top, BannerPosition.Bottom, BannerPosition.TopLeft,
+            BannerPosition.TopRight, BannerPosition.BottomLeft, BannerPosition.BottomRight,
+            BannerPosition.Center
+        };
+
+        BannerPosition current = AdsManager.Instance.CurrentBannerPosition;
+        int currentIndex = Array.IndexOf(positions, current);
+        int nextIndex = (currentIndex + 1) % positions.Length;
+        BannerPosition nextPosition = positions[nextIndex];
+
+        LogTest($"Cycling Banner Position: {current} → {nextPosition}");
+        AdsManager.Instance.SetBannerPosition(nextPosition);
+    }
+
+    public void TestBannerSizes()
+    {
+        BannerSize[] sizes = {
+            BannerSize.Banner, BannerSize.LargeBanner, BannerSize.MediumRectangle,
+            BannerSize.FullBanner, BannerSize.Leaderboard, BannerSize.Adaptive
+        };
+
+        BannerSize randomSize = sizes[UnityEngine.Random.Range(0, sizes.Length)];
+        LogTest($"Testing Banner Size: {randomSize}");
+        AdsManager.Instance.SetBannerSize(randomSize);
+    }
+    #endregion
+
+    #region Remove Ads Testing
+    public void TestEnableRemoveAds()
+    {
+        LogTest("Testing: Enable Remove Ads");
+        AdsManager.Instance.RemoveAds = true;
+    }
+
+    public void TestDisableRemoveAds()
+    {
+        LogTest("Testing: Disable Remove Ads (Re-enable Ads)");
+        AdsManager.Instance.RemoveAds = false;
+    }
+
+    public void TestToggleRemoveAds()
+    {
+        bool current = AdsManager.Instance.RemoveAds;
+        LogTest($"Toggling Remove Ads (Currently: {(current ? "Enabled" : "Disabled")})");
+        AdsManager.Instance.RemoveAds = !current;
+    }
+
+    public void TestPurchaseRemoveAds()
+    {
+        LogTest("Simulating Remove Ads Purchase");
+        // Simulate a successful purchase
+        AdsManager.Instance.RemoveAds = true;
+        LogTest("Remove Ads purchased and saved!");
+    }
+    #endregion
+
+    #region Ad Status Testing
+    public void CheckAllAdStatus()
+    {
+        LogTest("Checking All Ad Status:");
+        LogTest($"   Banner Ready: {AdsManager.Instance.IsBannerLoaded()}");
+        LogTest($"   Interstitial Ready: {AdsManager.Instance.IsInterstitialReady()}");
+        LogTest($"   Rewarded Ready: {AdsManager.Instance.IsRewardedReady()}");
+        LogTest($"   Rewarded Interstitial Ready: {AdsManager.Instance.IsRewardedInterstitialReady()}");
+        LogTest($"   App Open Available: {AdsManager.Instance.IsAppOpenAdAvailable()}");
+        LogTest($"   Remove Ads Enabled: {AdsManager.Instance.RemoveAds}");
+        LogTest($"   Ads Manager Initialized: {AdsManager.Instance.IsInitialized}");
+        LogTest($"   Currently Showing Ad: {AdsManager.Instance.IsShowingAd}");
+    }
+
+    public void CheckAdIds()
+    {
+        LogTest("Checking Current Ad Unit IDs:");
+        AdsManager.Instance.LogCurrentAdIds();
+
+        bool isTest = AdsManager.Instance.AreTestAdIds();
+        bool isValid = AdsManager.Instance.AreAdIdsValid();
+
+        LogTest($"   Using Test IDs: {isTest}");
+        LogTest($"   IDs Valid: {isValid}");
+
+        if (isTest)
+        {
+            LogTest("   WARNING: Using Google test Ad Unit IDs!");
+        }
+    }
+    #endregion
+
+    #region Comprehensive Testing
+    [ContextMenu("Test All Ads Sequentially")]
+    public void TestAllAdsSequentially()
+    {
+        LogTest("Starting Comprehensive Ad Test Sequence");
+        StartCoroutine(TestSequence());
+    }
+
+    private System.Collections.IEnumerator TestSequence()
+    {
+        LogTest("1. Testing Banner Ad");
+        ShowBannerTestCall();
+        yield return new WaitForSeconds(3f);
+
+        LogTest("2. Testing Interstitial Ad");
+        CallInterstitial(2);
+        yield return new WaitForSeconds(1f);
+
+        LogTest("3. Testing Rewarded Ad");
+        CallRewarded(3);
+        yield return new WaitForSeconds(1f);
+
+        LogTest("4. Testing Rewarded Interstitial Ad");
+        CallRewardedInterstitial(3);
+        yield return new WaitForSeconds(1f);
+
+        LogTest("5. Testing App Open Ad");
+        CallAppOpen(2);
+        yield return new WaitForSeconds(1f);
+
+        LogTest("Comprehensive test sequence completed!");
+    }
+
+    [ContextMenu("Test Remove Ads Functionality")]
+    public void TestRemoveAdsFunctionality()
+    {
+        LogTest("Testing Remove Ads Functionality");
+        StartCoroutine(RemoveAdsTestSequence());
+    }
+
+    private System.Collections.IEnumerator RemoveAdsTestSequence()
+    {
+        LogTest("Initial Status:");
+        CheckAllAdStatus();
+
+        yield return new WaitForSeconds(2f);
+
+        LogTest("Enabling Remove Ads...");
+        TestEnableRemoveAds();
+
+        yield return new WaitForSeconds(1f);
+
+        LogTest("Status After Enabling Remove Ads:");
+        CheckAllAdStatus();
+
+        yield return new WaitForSeconds(2f);
+
+        LogTest("Re-enabling Ads...");
+        TestDisableRemoveAds();
+
+        yield return new WaitForSeconds(1f);
+
+        LogTest("Final Status:");
+        CheckAllAdStatus();
+
+        LogTest("Remove Ads functionality test completed!");
+    }
+    #endregion
+
+    #region Utility Methods
+    private void LogTest(string message)
+    {
+        if (showDetailedLogs)
+        {
+            OnDebugLog?.Invoke($"{message}");
+            Debug.Log($"[TestCalls] {message}");
+        }
+    }
+
+    public void ClearDebugLog()
+    {
+        textLog = "ADMOB DEBUG LOG: \n";
+        if (debugLogText != null)
+        {
+            debugLogText.text = textLog;
+        }
+    }
+
+    // Context Menu items for easy testing
+    [ContextMenu("Show Interstitial")]
+    private void ContextShowInterstitial() => CallInterstitial(2);
+
+    [ContextMenu("Show Rewarded")]
+    private void ContextShowRewarded() => CallRewarded(3);
+
+    [ContextMenu("Show Rewarded Interstitial")]
+    private void ContextShowRewardedInterstitial() => CallRewardedInterstitial(3);
+
+    [ContextMenu("Show App Open")]
+    private void ContextShowAppOpen() => CallAppOpen(2);
+
+    [ContextMenu("Toggle Banner")]
+    private void ContextToggleBanner() => ToggleBannerTestCall();
+
+    [ContextMenu("Toggle Remove Ads")]
+    private void ContextToggleRemoveAds() => TestToggleRemoveAds();
+
+    [ContextMenu("Check All Status")]
+    private void ContextCheckStatus() => CheckAllAdStatus();
+    #endregion
+
+    #region Consent & Privacy Options (NEW)
+    private void SubscribeToConsentEvents()
+    {
+        if (AdsManager.Instance?.consentManager != null)
+        {
+            AdsManager.Instance.consentManager.OnConsentReady += OnConsentStatusChanged;
+            AdsManager.Instance.consentManager.OnConsentError += OnConsentError;
+        }
+    }
+
+    private void UnsubscribeFromConsentEvents()
+    {
+        if (AdsManager.Instance?.consentManager != null)
+        {
+            AdsManager.Instance.consentManager.OnConsentReady -= OnConsentStatusChanged;
+            AdsManager.Instance.consentManager.OnConsentError -= OnConsentError;
+        }
+    }
+
+    private void OnConsentStatusChanged(bool canRequestAds)
+    {
+        if (canRequestAds)
+        {
+            LogTest("✅ Consent Status: CAN REQUEST ADS");
+        }
+        else
+        {
+            LogTest("❌ Consent Status: CANNOT REQUEST ADS (User revoked or denied)");
+        }
+        
+        LogConsentDetails();
+    }
+
+    private void OnConsentError(string errorMessage)
+    {
+        LogTest($"⚠️ CONSENT ERROR: {errorMessage}");
+    }
+
+    public void ShowPrivacyOptions()
+    {
+        LogTest("Opening Privacy Options Form...");
+        
+        if (AdsManager.Instance.ShouldShowPrivacyOptionsButton())
+        {
+            AdsManager.Instance.ShowPrivacyOptionsForm();
+        }
+        else
+        {
+            LogTest("Privacy Options not required (user not in EEA or already declined)");
+        }
+    }
+
+    public void LogConsentDetails()
+    {
+        LogTest("=== CONSENT STATUS ===");
+        LogTest($"Can Request Ads: {AdsManager.Instance.CanUserRequestAds()}");
+        LogTest($"Consent Status: {AdsManager.Instance.GetCurrentConsentStatus()}");
+        
+        string consentType = AdsManager.Instance.GetConsentType();
+        LogTest($"Consent Type: {consentType}");
+        
+        string tcfString = AdsManager.Instance.GetTCFConsentString();
+        if (!string.IsNullOrEmpty(tcfString))
+        {
+            LogTest($"TCF String: {tcfString.Substring(0, Math.Min(30, tcfString.Length))}...");
+            
+            bool hasStorage = AdsManager.Instance.HasConsentForPurpose(1);
+            bool hasPersonalization = AdsManager.Instance.HasConsentForPurpose(3);
+            bool hasAdSelection = AdsManager.Instance.HasConsentForPurpose(4);
+            bool hasAnalytics = AdsManager.Instance.HasConsentForPurpose(7);
+            
+            LogTest($"TCF Purposes:");
+            LogTest($"  - Storage (1): {hasStorage}");
+            LogTest($"  - Personalization (3): {hasPersonalization}");
+            LogTest($"  - Ad Selection (4): {hasAdSelection}");
+            LogTest($"  - Analytics (7): {hasAnalytics}");
+        }
+        else
+        {
+            LogTest("TCF String: Not available");
+        }
+        
+        LogTest("======================");
+    }
+
+    [ContextMenu("Show Privacy Options")]
+    private void ContextShowPrivacyOptions() => ShowPrivacyOptions();
+
+    [ContextMenu("Log Consent Details")]
+    private void ContextLogConsentDetails() => LogConsentDetails();
+
+    [ContextMenu("Check Consent Status")]
+    private void ContextCheckConsentStatus()
+    {
+        AdsManager.Instance.CheckConsentStatus();
+        LogTest("Manually triggered consent status check");
+    }
+    #endregion
+
+}

--- a/Samples~/ExampleScene/Scripts/AdsExampleUI.cs.meta
+++ b/Samples~/ExampleScene/Scripts/AdsExampleUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 42d819e6650e01a45b98048038529083
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/ExampleScene/Scripts/ConsentEnhancementsExample.cs
+++ b/Samples~/ExampleScene/Scripts/ConsentEnhancementsExample.cs
@@ -1,0 +1,130 @@
+using UnityEngine;
+using GoogleMobileAds.Ump.Api;
+
+namespace Autech.Admob
+{
+    public class ConsentEnhancementsExample : MonoBehaviour
+    {
+        [Header("UI References (Optional)")]
+        [SerializeField] private UnityEngine.UI.Text statusText;
+
+        private void Start()
+        {
+            SubscribeToConsentEvents();
+        }
+
+        private void OnDestroy()
+        {
+            UnsubscribeFromConsentEvents();
+        }
+
+        private void SubscribeToConsentEvents()
+        {
+            if (AdsManager.Instance != null && AdsManager.Instance.consentManager != null)
+            {
+                AdsManager.Instance.consentManager.OnConsentReady += OnConsentReady;
+                AdsManager.Instance.consentManager.OnConsentError += OnConsentError;
+            }
+        }
+
+        private void UnsubscribeFromConsentEvents()
+        {
+            if (AdsManager.Instance != null && AdsManager.Instance.consentManager != null)
+            {
+                AdsManager.Instance.consentManager.OnConsentReady -= OnConsentReady;
+                AdsManager.Instance.consentManager.OnConsentError -= OnConsentError;
+            }
+        }
+
+        private void OnConsentReady(bool canRequestAds)
+        {
+            if (canRequestAds)
+            {
+                Debug.Log("[ConsentEnhancementsExample] Consent obtained - ads enabled");
+                UpdateStatusText("Ads Enabled");
+                LogConsentDetails();
+            }
+            else
+            {
+                Debug.Log("[ConsentEnhancementsExample] Consent denied - ads disabled");
+                UpdateStatusText("Ads Disabled - Consent Required");
+            }
+        }
+
+        private void OnConsentError(string errorMessage)
+        {
+            Debug.LogError($"[ConsentEnhancementsExample] Consent error: {errorMessage}");
+            UpdateStatusText($"Error: {errorMessage}");
+        }
+
+        private void LogConsentDetails()
+        {
+            string consentType = AdsManager.Instance.GetConsentType();
+            Debug.Log($"[ConsentEnhancementsExample] Consent Type: {consentType}");
+            
+            switch (consentType)
+            {
+                case "Personalized":
+                    Debug.Log("[ConsentEnhancementsExample] Showing personalized ads");
+                    break;
+                case "NonPersonalized":
+                    Debug.Log("[ConsentEnhancementsExample] Showing non-personalized ads");
+                    break;
+                case "NotRequired":
+                    Debug.Log("[ConsentEnhancementsExample] Consent not required (non-EEA region)");
+                    break;
+                case "Unknown":
+                    Debug.Log("[ConsentEnhancementsExample] Consent type unknown");
+                    break;
+            }
+
+            LogTCFConsentStatus();
+        }
+
+        private void LogTCFConsentStatus()
+        {
+            string tcfString = AdsManager.Instance.GetTCFConsentString();
+            if (!string.IsNullOrEmpty(tcfString))
+            {
+                Debug.Log($"[ConsentEnhancementsExample] TCF String: {tcfString}");
+                
+                bool hasStorageConsent = AdsManager.Instance.HasConsentForPurpose(1);
+                bool hasPersonalizedAdsConsent = AdsManager.Instance.HasConsentForPurpose(3);
+                bool hasAdSelectionConsent = AdsManager.Instance.HasConsentForPurpose(4);
+                
+                Debug.Log($"[ConsentEnhancementsExample] TCF Purposes - Storage: {hasStorageConsent}, Personalized Profile: {hasPersonalizedAdsConsent}, Ad Selection: {hasAdSelectionConsent}");
+            }
+        }
+
+        private void UpdateStatusText(string message)
+        {
+            if (statusText != null)
+            {
+                statusText.text = message;
+            }
+        }
+
+        [ContextMenu("Show Privacy Options")]
+        public void ShowPrivacyOptions()
+        {
+            Debug.Log("[ConsentEnhancementsExample] Showing privacy options form");
+            AdsManager.Instance.ShowPrivacyOptionsForm();
+        }
+
+        [ContextMenu("Check Current Consent Status")]
+        public void CheckConsentStatus()
+        {
+            Debug.Log("[ConsentEnhancementsExample] Manually checking consent status");
+            AdsManager.Instance.CheckConsentStatus();
+        }
+
+        [ContextMenu("Log Consent Details")]
+        public void LogCurrentConsentDetails()
+        {
+            Debug.Log("=== CONSENT STATUS ===");
+            Debug.Log($"Can Request Ads: {AdsManager.Instance.consentManager?.CanUserRequestAds()}");
+            Debug.Log($"Consent Status: {AdsManager.Instance.consentManager?.GetCurrentConsentStatus()}");
+            LogConsentDetails();
+        }
+    }
+}

--- a/Samples~/ExampleScene/Scripts/ConsentEnhancementsExample.cs.meta
+++ b/Samples~/ExampleScene/Scripts/ConsentEnhancementsExample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9792914e0492d354cac7341a0989b927

--- a/Samples~/ExampleScene/Scripts/ConsentUIExample.cs
+++ b/Samples~/ExampleScene/Scripts/ConsentUIExample.cs
@@ -1,0 +1,331 @@
+using UnityEngine;
+using UnityEngine.UI;
+using GoogleMobileAds.Ump.Api;
+using Autech.Admob;
+
+namespace AdmobMediationPackage
+{
+    /// <summary>
+    /// Example UI script demonstrating how to use the new consent management features.
+    /// This shows best practices for implementing GDPR-compliant ad controls in your game.
+    /// IMPORTANT: This script uses AdsManager.Instance for ad operations and VerifyAdmob for configuration/consent.
+    /// Updated for refactored architecture with modular components and async/await.
+    /// </summary>
+    public class ConsentUIExample : MonoBehaviour
+    {
+        [Header("UI References")]
+        [SerializeField] private Button privacySettingsButton;
+        [SerializeField] private Button refreshConsentButton;
+        [SerializeField] private Button logStatusButton;
+        [SerializeField] private Button showInterstitialButton;
+        [SerializeField] private Button showRewardedButton;
+        
+        [Header("Status Display")]
+        [SerializeField] private Text consentStatusText;
+        [SerializeField] private Text canRequestAdsText;
+        [SerializeField] private GameObject adControlsPanel;
+        
+        [Header("Dependencies - Assign in Inspector")]
+        [SerializeField] private VerifyAdmob verifyAdmob;
+
+        private void Start()
+        {
+            // Validate that we have the required components
+            if (verifyAdmob == null)
+            {
+                Debug.LogError("[ConsentUIExample] VerifyAdmob reference not assigned! Please assign it in the Inspector.");
+                return;
+            }
+
+            if (AdsManager.Instance == null)
+            {
+                Debug.LogError("[ConsentUIExample] AdsManager.Instance is null! Make sure AdsManager is properly initialized.");
+                return;
+            }
+
+            SetupButtons();
+            UpdateUI();
+            
+            // Update UI every few seconds to reflect any changes
+            InvokeRepeating(nameof(UpdateUI), 1f, 3f);
+        }
+
+        private void SetupButtons()
+        {
+            // Privacy Settings Button
+            if (privacySettingsButton != null)
+            {
+                privacySettingsButton.onClick.AddListener(ShowPrivacyOptions);
+            }
+
+            // Refresh Consent Button
+            if (refreshConsentButton != null)
+            {
+                refreshConsentButton.onClick.AddListener(RefreshConsent);
+            }
+
+            // Log Status Button (for debugging)
+            if (logStatusButton != null)
+            {
+                logStatusButton.onClick.AddListener(LogConsentStatus);
+            }
+
+            // Ad Buttons
+            if (showInterstitialButton != null)
+            {
+                showInterstitialButton.onClick.AddListener(ShowInterstitialAd);
+            }
+
+            if (showRewardedButton != null)
+            {
+                showRewardedButton.onClick.AddListener(ShowRewardedAd);
+            }
+        }
+
+        private void UpdateUI()
+        {
+            if (verifyAdmob == null || AdsManager.Instance == null) return;
+
+            // Update consent status display
+            if (consentStatusText != null)
+            {
+                ConsentStatus status = verifyAdmob.GetCurrentConsentStatus();
+                consentStatusText.text = $"Consent Status: {status}";
+                
+                // Color code the status
+                switch (status)
+                {
+                    case ConsentStatus.Obtained:
+                        consentStatusText.color = Color.green;
+                        break;
+                    case ConsentStatus.Required:
+                        consentStatusText.color = Color.yellow;
+                        break;
+                    case ConsentStatus.NotRequired:
+                        consentStatusText.color = Color.blue;
+                        break;
+                    default:
+                        consentStatusText.color = Color.gray;
+                        break;
+                }
+            }
+
+            // Update can request ads status
+            if (canRequestAdsText != null)
+            {
+                bool canRequestAds = verifyAdmob.CanUserRequestAds();
+                canRequestAdsText.text = $"Can Request Ads: {canRequestAds}";
+                canRequestAdsText.color = canRequestAds ? Color.green : Color.red;
+            }
+
+            // Show/hide privacy settings button based on requirement
+            if (privacySettingsButton != null)
+            {
+                bool shouldShow = verifyAdmob.ShouldShowPrivacyOptionsButton();
+                privacySettingsButton.gameObject.SetActive(shouldShow);
+            }
+
+            // Show/hide ad controls based on consent and remove ads status
+            if (adControlsPanel != null)
+            {
+                bool canShowAds = verifyAdmob.CanUserRequestAds() && 
+                                 !verifyAdmob.IsRemoveAdsEnabled() &&
+                                 AdsManager.Instance.IsInitialized;
+                adControlsPanel.SetActive(canShowAds);
+            }
+
+            // Update interactability of ad buttons
+            bool adsAvailable = verifyAdmob.CanUserRequestAds() && 
+                               !verifyAdmob.IsRemoveAdsEnabled() &&
+                               AdsManager.Instance.IsInitialized;
+
+            if (showInterstitialButton != null)
+            {
+                showInterstitialButton.interactable = adsAvailable;
+            }
+
+            if (showRewardedButton != null)
+            {
+                showRewardedButton.interactable = adsAvailable;
+            }
+        }
+
+        #region Button Event Handlers
+
+        /// <summary>
+        /// Shows the privacy options form to let users manage their consent.
+        /// This should be accessible from your game's settings menu.
+        /// </summary>
+        public void ShowPrivacyOptions()
+        {
+            Debug.Log("[ConsentUIExample] Privacy options requested by user");
+            verifyAdmob.ShowPrivacyOptionsForm();
+            
+            // Update UI after a short delay to reflect any changes
+            Invoke(nameof(UpdateUI), 1f);
+        }
+
+        /// <summary>
+        /// Manually refreshes mediation consent for all networks.
+        /// Useful for debugging or when you've added new mediation networks.
+        /// </summary>
+        public void RefreshConsent()
+        {
+            Debug.Log("[ConsentUIExample] Consent refresh requested by user");
+            verifyAdmob.RefreshMediationConsent();
+            UpdateUI();
+        }
+
+        /// <summary>
+        /// Logs comprehensive consent status for debugging purposes.
+        /// </summary>
+        public void LogConsentStatus()
+        {
+            Debug.Log("[ConsentUIExample] Logging consent status for debugging");
+            verifyAdmob.LogConsentStatus();
+        }
+
+        /// <summary>
+        /// Shows an interstitial ad with proper consent checking.
+        /// Uses AdsManager.Instance for actual ad display.
+        /// </summary>
+        public void ShowInterstitialAd()
+        {
+            if (!CanShowAds())
+            {
+                Debug.LogWarning("[ConsentUIExample] Cannot show interstitial - consent or remove ads issue");
+                ShowAdUnavailableMessage();
+                return;
+            }
+
+            Debug.Log("[ConsentUIExample] Showing interstitial ad");
+            AdsManager.Instance.ShowInterstitial();
+        }
+
+        /// <summary>
+        /// Shows a rewarded ad with proper consent checking.
+        /// Uses AdsManager.Instance for actual ad display.
+        /// </summary>
+        public void ShowRewardedAd()
+        {
+            if (!CanShowAds())
+            {
+                Debug.LogWarning("[ConsentUIExample] Cannot show rewarded ad - consent or remove ads issue");
+                ShowAdUnavailableMessage();
+                return;
+            }
+
+            Debug.Log("[ConsentUIExample] Showing rewarded ad");
+            AdsManager.Instance.ShowRewarded();
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Comprehensive check if ads can be shown right now.
+        /// Uses both VerifyAdmob for configuration/consent and AdsManager for initialization status.
+        /// </summary>
+        private bool CanShowAds()
+        {
+            if (verifyAdmob == null)
+            {
+                Debug.LogError("[ConsentUIExample] VerifyAdmob reference is null");
+                return false;
+            }
+
+            if (AdsManager.Instance == null)
+            {
+                Debug.LogError("[ConsentUIExample] AdsManager.Instance is null");
+                return false;
+            }
+
+            // Check if user has consented to ads
+            if (!verifyAdmob.CanUserRequestAds())
+            {
+                Debug.Log("[ConsentUIExample] User has not consented to ads");
+                return false;
+            }
+
+            // Check if remove ads is purchased
+            if (verifyAdmob.IsRemoveAdsEnabled())
+            {
+                Debug.Log("[ConsentUIExample] Remove ads is enabled");
+                return false;
+            }
+
+            // Check if AdMob is initialized
+            if (!AdsManager.Instance.IsInitialized)
+            {
+                Debug.Log("[ConsentUIExample] AdMob is not yet initialized");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Shows a user-friendly message about why ads can't be shown.
+        /// Call this when ad requests fail due to consent issues.
+        /// </summary>
+        public void ShowAdUnavailableMessage()
+        {
+            string message = "";
+
+            if (!verifyAdmob.CanUserRequestAds())
+            {
+                ConsentStatus status = verifyAdmob.GetCurrentConsentStatus();
+                switch (status)
+                {
+                    case ConsentStatus.Required:
+                        message = "Ads require your consent. Please check privacy settings.";
+                        break;
+                    case ConsentStatus.Unknown:
+                        message = "Checking consent status. Please try again in a moment.";
+                        break;
+                    default:
+                        message = "Ads are not available at this time.";
+                        break;
+                }
+            }
+            else if (verifyAdmob.IsRemoveAdsEnabled())
+            {
+                message = "Ads have been removed. Thank you for your purchase!";
+            }
+            else if (!AdsManager.Instance.IsInitialized)
+            {
+                message = "Ads are loading. Please try again in a moment.";
+            }
+
+            Debug.Log($"[ConsentUIExample] Ad unavailable: {message}");
+            
+            // Here you would show this message to the user in your UI
+            // For example: ShowToast(message) or UpdateStatusText(message)
+        }
+
+        #endregion
+
+        #region Context Menu Methods (for debugging)
+
+        [ContextMenu("Test Privacy Options")]
+        private void TestPrivacyOptions()
+        {
+            ShowPrivacyOptions();
+        }
+
+        [ContextMenu("Test Consent Refresh")]
+        private void TestConsentRefresh()
+        {
+            RefreshConsent();
+        }
+
+        [ContextMenu("Force UI Update")]
+        private void ForceUIUpdate()
+        {
+            UpdateUI();
+        }
+
+        #endregion
+    }
+}

--- a/Samples~/ExampleScene/Scripts/ConsentUIExample.cs.meta
+++ b/Samples~/ExampleScene/Scripts/ConsentUIExample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41020fd7a5580c14a9d3149fa5e49874

--- a/Samples~/Scripts.meta
+++ b/Samples~/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "samples": [
     {
       "displayName": "Example Scene and UI",
-      "description": "Complete example scene showing AdMob integration with UI controls and consent management",
+      "description": "Complete example scene with scripts showing AdMob integration, UI controls, and consent management",
       "path": "Samples~/ExampleScene"
     },
     {


### PR DESCRIPTION
Changes:
- Added Samples~/ExampleScene/Scripts/ folder with example scripts:
  * AdsExampleUI.cs - Complete UI example for all ad types
  * ConsentUIExample.cs - Consent management UI example
  * ConsentEnhancementsExample.cs - Advanced consent features
- Updated ExampleAdsScene.unity to latest version from Assets
- Updated VerifyandInitializeAdmob.prefab to latest version
- Updated package.json sample description to mention scripts

Issue Fixed:
- Samples~ folder was missing scripts, causing empty import
- Scene and prefab were outdated compared to Assets/Admob
- Users importing samples now get complete working examples

All samples are now in sync with Assets/Admob and include all necessary files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive example scripts demonstrating ad testing workflows (interstitial, rewarded, banner ads, and app open ads) with UI controls and debug logging.
  * Added consent management example scripts showing privacy options integration and status monitoring.
  * New sample scene with interactive buttons for testing various ad types and remove-ads functionality.

* **Documentation**
  * Updated package sample description to clarify included example scripts and consent management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->